### PR TITLE
Bug: Remove research from non-agent prompt

### DIFF
--- a/src/server/prompts/dev.code_new_or_edit.system.txt
+++ b/src/server/prompts/dev.code_new_or_edit.system.txt
@@ -1,8 +1,6 @@
 You are the top, most distinguished Technical Fellow at Microsoft.
 You are the best software engineer in the world and always write flawless production-level code.
 Here are some details to help with your task.
-## Research (optional)
-${research}
 
 ## Types (optional)
 ${types}

--- a/src/server/utils/index.test.ts
+++ b/src/server/utils/index.test.ts
@@ -27,7 +27,6 @@ const originalPromptsFolder = process.env.PROMPT_FOLDER ?? "src/server/prompts";
 
 describe("constructNewOrEditSystemPrompt", () => {
   const mockParams: TemplateParams = {
-    research: "research",
     types: "types",
     packages: "packages",
     sourceMap: "sourceMap",
@@ -60,8 +59,6 @@ describe("constructNewOrEditSystemPrompt", () => {
       You are the top, most distinguished Technical Fellow at Microsoft.
       You are the best software engineer in the world and always write flawless production-level code.
       Here are some details to help with your task.
-      ## Research (optional)
-      research
       
       ## Types (optional)
       types
@@ -105,8 +102,6 @@ describe("constructNewOrEditSystemPrompt", () => {
       You are the top, most distinguished Technical Fellow at Microsoft.
       You are the best software engineer in the world and always write flawless production-level code.
       Here are some details to help with your task.
-      ## Research (optional)
-      research
 
       ## Types (optional)
       types
@@ -159,8 +154,6 @@ describe("constructNewOrEditSystemPrompt", () => {
       You are the top, most distinguished Technical Fellow at Microsoft.
       You are the best software engineer in the world and always write flawless production-level code.
       Here are some details to help with your task.
-      ## Research (optional)
-      research
 
       ## Types (optional)
       types
@@ -213,8 +206,6 @@ describe("constructNewOrEditSystemPrompt", () => {
   You are the top, most distinguished Technical Fellow at Microsoft.
   You are the best software engineer in the world and always write flawless production-level code.
   Here are some details to help with your task.
-  ## Research (optional)
-  research
 
   ## Types (optional)
   types
@@ -275,8 +266,6 @@ describe("constructNewOrEditSystemPrompt", () => {
 You are the top, most distinguished Technical Fellow at Microsoft.
 You are the best software engineer in the world and always write flawless production-level code.
 Here are some details to help with your task.
-## Research (optional)
-research
 
 ## Types (optional)
 types


### PR DESCRIPTION
## Bug Report
- The research variable is not passed to calls to `constructNewOrEditSystemPrompt`, so JACoB runs into `Missing required variables: research` when trying to edit files.

## Changes
- This PR removes the research variable and heading from the `dev.code_new_or_edit.system.txt` prompt

## Context
- This was already fixed [here](https://github.com/jacob-ai-bot/jacob/commit/2e2b1b79713d3cf408ef711980682158eccb30bf) and [here](https://github.com/jacob-ai-bot/jacob/commit/75ff1b7e582eaedf46421c1ddda162b5d27cc13c) by @cpirich, but I wanted to merge this into master for testing JACoB locally.