### PR TITLE
Refactor `getOrCreateTodo()`

### DIFF
--- a/src/server/code/editFiles.test.ts
+++ b/src/server/code/editFiles.test.ts
@@ -84,6 +84,11 @@ const mockedDb = vi.hoisted(() => ({
 }));
 vi.mock("~/server/db/db", () => ({ db: mockedDb }));
 
+const mockedTodos = vi.hoisted(() => ({
+  getOrCreateTodo: vi.fn().mockResolvedValue({}),
+}));
+vi.mock("../utils/todos", () => mockedTodos);
+
 const mockedPlan = vi.hoisted(() => ({
   getOrGeneratePlan: vi.fn().mockResolvedValue({
     steps: [
@@ -172,5 +177,8 @@ describe("editFiles", () => {
     expect(mockedDb.research.where).toHaveBeenCalledWith({
       issueId: issue.number,
     });
+
+    // Because the research data is already present, we don't need to create a todo
+    expect(mockedTodos.getOrCreateTodo).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Description
* Since we now create todos within `editFiles`, it makes sense to pass some additional parameters to that function so we don't need clone the repo a second time and recompute a source map
* While at it, I changed the `createTodo()` function to be `getOrCreateTodo()` so you don't need to check for the todo's existence beforehand (it was already checking within)