### PR TITLE
Tweak skipBuild handling on installCommand

### DIFF
--- a/src/server/build/node/check.ts
+++ b/src/server/build/node/check.ts
@@ -80,15 +80,19 @@ export async function runBuildCheck({
     }`;
 
   try {
-    await executeWithLogRequiringSuccess({
-      ...baseEventData,
-      directory: path,
-      command: installCommand,
-      options: {
-        env,
-        timeout: INSTALL_TIMEOUT,
-      },
-    });
+    if (!shouldSkipBuild || formatCommand) {
+      // Even if we are skipping the build, we still need to install
+      // if we're planning to run the format command
+      await executeWithLogRequiringSuccess({
+        ...baseEventData,
+        directory: path,
+        command: installCommand,
+        options: {
+          env,
+          timeout: INSTALL_TIMEOUT,
+        },
+      });
+    }
 
     if (afterModifications && formatCommand) {
       try {


### PR DESCRIPTION
## Description
* https://github.com/jacob-ai-bot/jacob/pull/198 caused `--skip-build` to no longer disable all of the default build logic for Python repos without a `jacob.json` file. Since `npm install` was restored to ensure that the format command could run, we now skip `npm install` if `skipBuild` and there is no `formatCommand` specified