### PR TITLE
Fix `--branch` command naming, add tests

### DIFF
--- a/src/server/code/editFiles.test.ts
+++ b/src/server/code/editFiles.test.ts
@@ -136,6 +136,7 @@ describe("editFiles", () => {
     token: "token",
     issue,
     rootPath: "/rootpath",
+    baseBranch: "base-branch",
     sourceMap: "source map",
   };
 
@@ -171,6 +172,7 @@ describe("editFiles", () => {
     expect(mockedCheckAndCommit.checkAndCommit).toHaveBeenLastCalledWith(
       expect.objectContaining({
         newPrBody: expect.stringContaining("## Plan:\n"),
+        baseBranch: "base-branch",
       }),
     );
 

--- a/src/server/messaging/queue.test.ts
+++ b/src/server/messaging/queue.test.ts
@@ -318,7 +318,7 @@ describe("onGitHubEvent", () => {
           ...issuesOpenedEditFilesPayload.issue,
           body:
             issuesOpenedEditFilesPayload.issue.body +
-            "\n\n--base-branch foo-branch  \n",
+            "\n\n--branch foo-branch  \n",
         },
       },
     } as WebhookIssueOpenedEvent);

--- a/src/server/messaging/queue.ts
+++ b/src/server/messaging/queue.ts
@@ -31,6 +31,7 @@ import {
   enumFromStringValue,
   getRepoSettings,
   extractIssueNumberFromBranchName,
+  CUSTOM_BRANCH,
   SKIP_BUILD,
   SKIP_DEBUGGING,
   SKIP_STORYBOOK,
@@ -520,7 +521,7 @@ export async function onGitHubEvent(event: WebhookQueuedEvent) {
   const baseBranch =
     prBranch ??
     (issueOpened && body
-      ? /--base-branch +(\S+)[\s|\n]+/gm.exec(body)?.[1]
+      ? new RegExp(`${CUSTOM_BRANCH} +(\\S+)[\\s|\\n]+`, "gm").exec(body)?.[1]
       : undefined);
 
   const newFileName = issueOpenedTitle


### PR DESCRIPTION
## Description
* The code mistakenly used `--base-branch` in one place and `--branch` in another. Fixed now - and added more tests!

NOTE: The current version of the command is `--branch`