### PR TITLE
Use DB instead of ENV to decide on enabled users and repos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,6 @@ AWS_REGION="us-west-2"
 BUCKET_NAME="jacob-snapshots"
 POSTHOG_API_KEY="sample-api-key"
 TMP_DIR="/tmp"
-DASHBOARD_USERS="your-github-login"
-AGENT_REPOS="org1/repo1,org2/repo2"
 
 PUBSUB_REDIS_URL="redis://localhost:6379/0"
 PUBSUB_REDIS_TEST_URL="redis://localhost:6379/1"

--- a/README.md
+++ b/README.md
@@ -185,7 +185,8 @@ JACoB works via a custom GitHub app and a Figma Plugin, along with a command-lin
      - Set the `GITHUB_PRIVATE_KEY` generated in the GitHub app setup
      - From the a GitHub app, populate the `GITHUB_APP_ID`, the `GITHUB_APP_NAME`, the `GITHUB_CLIENT_ID`, and the `GITHUB_CLIENT_SECRET` (note that this needs to be populated as both `GITHUB_CLIENT_SECRET` and `VITE_GITHUB_CLIENT_SECRET` in the `.env` file)
      - Determine the `GITHUB_APP_USERNAME` by calling a URL like this https://api.github.com/users/[GITHUB_APP_NAME][bot] and look at the `id` in the response (it will be a number)
-     - Add your GitHub username to the `DASHBOARD_USERS` variable
+     - Later: After logging in to the local website, set the dashboardEnabled value on your row in the users table to TRUE. Set the role on this row to 'admin'.
+     - Later: After connecting a repo to the local GitHub app, set the agentEnabled value on the associated row in the projects table to TRUE
    - Ensure the app is listening for the following webhook events: `Issue comments`, `Issues`, `Pull request review comments`, and `Pull request reviews`
 
 2. **Infrastructure with Docker**

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -9,7 +9,6 @@ import { SignOutButton } from "~/app/_components/SignOutButton";
 import { db } from "~/server/db/db";
 import { type Project } from "~/server/db/tables/projects.table";
 import { type User } from "~/server/db/tables/users.table";
-import { getDashboardUsers } from "~/app/utils";
 import {
   Table,
   TableBody,
@@ -27,12 +26,6 @@ const getProjects = cache(async () => {
 const getUsers = cache(async () => {
   return db.users.order({ login: "ASC" }).all();
 });
-
-const agentRepos = process.env.AGENT_REPOS?.split(",").map((repo) =>
-  repo.trim(),
-);
-
-const dashboardUsers = getDashboardUsers();
 
 interface ProjectsTableProps {
   projects: Project[];
@@ -55,7 +48,7 @@ function ProjectsTable({ projects }: ProjectsTableProps) {
             <TableCell className="font-medium">{project.id}</TableCell>
             <TableCell>{project.repoFullName}</TableCell>
             <TableCell className="text-right">
-              {agentRepos?.includes(project.repoFullName) ? "YES" : ""}
+              {project.agentEnabled ? "YES" : ""}
             </TableCell>
           </TableRow>
         ))}
@@ -89,7 +82,7 @@ function UsersTable({ users }: UsersTableProps) {
             <TableCell>{user.name}</TableCell>
             <TableCell>{user.email}</TableCell>
             <TableCell className="text-right">
-              {dashboardUsers.includes(user.login ?? "") ? "YES" : ""}
+              {user.dashboardEnabled ? "YES" : ""}
             </TableCell>
           </TableRow>
         ))}

--- a/src/app/dashboard/[org]/[repo]/assigned-tasks/page.tsx
+++ b/src/app/dashboard/[org]/[repo]/assigned-tasks/page.tsx
@@ -3,7 +3,7 @@ import { getServerAuthSession } from "~/server/auth";
 
 import TasksPage from "./TasksPage";
 import { Suspense } from "react";
-import { getDashboardUsers } from "~/app/utils";
+
 interface PageProps {
   params: {
     org: string;
@@ -11,10 +11,9 @@ interface PageProps {
   };
 }
 
-const dashboardUsers = getDashboardUsers();
 export default async function LivePageRoute({ params }: PageProps) {
   const { user } = (await getServerAuthSession()) ?? {};
-  if (!user?.login || !dashboardUsers.includes(user.login.toLowerCase())) {
+  if (!user?.login || !user.dashboardEnabled) {
     redirect("/");
   }
 

--- a/src/app/dashboard/[org]/[repo]/chat/page.tsx
+++ b/src/app/dashboard/[org]/[repo]/chat/page.tsx
@@ -2,13 +2,10 @@ import { redirect } from "next/navigation";
 import { getServerAuthSession } from "~/server/auth";
 import ChatPage from "./ChatPage";
 import { Suspense } from "react";
-import { getDashboardUsers } from "~/app/utils";
-
-const dashboardUsers = getDashboardUsers();
 
 const Chat = async ({ params }: { params: { org: string; repo: string } }) => {
   const { user } = (await getServerAuthSession()) ?? {};
-  if (!user?.login || !dashboardUsers.includes(user.login.toLowerCase())) {
+  if (!user?.login || !user.dashboardEnabled) {
     redirect("/");
   }
   const { org, repo } = params;

--- a/src/app/dashboard/[org]/[repo]/design/page.tsx
+++ b/src/app/dashboard/[org]/[repo]/design/page.tsx
@@ -2,9 +2,6 @@ import { redirect } from "next/navigation";
 import { getServerAuthSession } from "~/server/auth";
 import Design from "./Design";
 import { Suspense } from "react";
-import { getDashboardUsers } from "~/app/utils";
-
-const dashboardUsers = getDashboardUsers();
 
 const DesignPage = async ({
   params,
@@ -12,7 +9,7 @@ const DesignPage = async ({
   params: { org: string; repo: string };
 }) => {
   const { user } = (await getServerAuthSession()) ?? {};
-  if (!user?.login || !dashboardUsers.includes(user.login.toLowerCase())) {
+  if (!user?.login || !user.dashboardEnabled) {
     redirect("/");
   }
 

--- a/src/app/dashboard/[org]/[repo]/issue-writer/page.tsx
+++ b/src/app/dashboard/[org]/[repo]/issue-writer/page.tsx
@@ -3,9 +3,6 @@ import { redirect } from "next/navigation";
 import IssueWriter from "./IssueWriter";
 import { getServerAuthSession } from "~/server/auth";
 import { Suspense } from "react";
-import { getDashboardUsers } from "~/app/utils";
-
-const dashboardUsers = getDashboardUsers();
 
 const IssueWriterPage = async ({
   params,
@@ -13,7 +10,7 @@ const IssueWriterPage = async ({
   params: { org: string; repo: string };
 }) => {
   const { user } = (await getServerAuthSession()) ?? {};
-  if (!user?.login || !dashboardUsers.includes(user.login.toLowerCase())) {
+  if (!user?.login || !user.dashboardEnabled) {
     redirect("/");
   }
 

--- a/src/app/dashboard/[org]/[repo]/settings/page.tsx
+++ b/src/app/dashboard/[org]/[repo]/settings/page.tsx
@@ -4,7 +4,6 @@ import { Suspense } from "react";
 import Settings from "./Settings";
 import { api } from "~/trpc/server";
 import LoadingPage from "~/app/dashboard/loading";
-import { getDashboardUsers } from "~/app/utils";
 
 interface PageProps {
   params: {
@@ -13,11 +12,9 @@ interface PageProps {
   };
 }
 
-const dashboardUsers = getDashboardUsers();
-
 export default async function SettingsPage({ params }: PageProps) {
   const { user } = (await getServerAuthSession()) ?? {};
-  if (!user?.login || !dashboardUsers.includes(user.login.toLowerCase())) {
+  if (!user?.login || !user.dashboardEnabled) {
     redirect("/");
   }
 

--- a/src/app/dashboard/[org]/[repo]/todos/page.tsx
+++ b/src/app/dashboard/[org]/[repo]/todos/page.tsx
@@ -2,9 +2,6 @@ import { redirect } from "next/navigation";
 
 import Todo from "./Todo";
 import { getServerAuthSession } from "~/server/auth";
-import { getDashboardUsers } from "~/app/utils";
-
-const dashboardUsers = getDashboardUsers();
 
 const TodoPage = async ({
   params,
@@ -12,7 +9,7 @@ const TodoPage = async ({
   params: { org: string; repo: string };
 }) => {
   const { user } = (await getServerAuthSession()) ?? {};
-  if (!user?.login || !dashboardUsers.includes(user.login.toLowerCase())) {
+  if (!user?.login || !user.dashboardEnabled) {
     redirect("/");
   }
 

--- a/src/app/setup/[login]/[org]/[repo]/setup/page.tsx
+++ b/src/app/setup/[login]/[org]/[repo]/setup/page.tsx
@@ -3,9 +3,6 @@ import { redirect } from "next/navigation";
 import { api } from "~/trpc/server";
 import { getServerAuthSession } from "~/server/auth";
 import Setup from "./Setup";
-import { getDashboardUsers } from "~/app/utils";
-
-const dashboardUsers = getDashboardUsers();
 
 const SetupPage = async ({
   params,
@@ -13,7 +10,7 @@ const SetupPage = async ({
   params: { org: string; repo: string; developer: string };
 }) => {
   const { user } = (await getServerAuthSession()) ?? {};
-  if (!user?.login || !dashboardUsers.includes(user.login.toLowerCase())) {
+  if (!user?.login || !user.dashboardEnabled) {
     redirect("/");
   }
 

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -246,10 +246,3 @@ export function includesIgnoreCase(
   if (!str || !searchString) return false;
   return str.toLowerCase().includes(searchString.toLowerCase());
 }
-
-export function getDashboardUsers(): string[] {
-  return (process.env.DASHBOARD_USERS ?? "")
-    .toLowerCase()
-    .split(",")
-    .map((user) => user.trim());
-}

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -34,6 +34,7 @@ declare module "next-auth" {
       id: string;
       login: string;
       role?: UserRole;
+      dashboardEnabled?: boolean;
       expires?: string; // ISO DateString
       // ...other properties
     } & DefaultSession["user"];

--- a/src/server/code/editFiles.ts
+++ b/src/server/code/editFiles.ts
@@ -42,6 +42,7 @@ export interface EditFilesParams extends BaseEventData {
   sourceMap: string;
   baseBranch?: string;
   dryRun?: boolean;
+  agentEnabled?: boolean;
   repoSettings?: RepoSettings;
 }
 
@@ -160,6 +161,7 @@ export async function editFiles(params: EditFilesParams) {
     sourceMap,
     baseBranch,
     dryRun,
+    agentEnabled,
     repoSettings,
     ...baseEventData
   } = params;
@@ -176,6 +178,7 @@ export async function editFiles(params: EditFilesParams) {
     accessToken: token,
     rootDir: rootPath,
     sourceMap,
+    agentEnabled,
     repoSettings,
   });
   if (!todo) {

--- a/src/server/messaging/queue.test.ts
+++ b/src/server/messaging/queue.test.ts
@@ -183,8 +183,6 @@ const mockedEvents = vi.hoisted(() => ({
 }));
 vi.mock("~/server/utils/events", () => mockedEvents);
 
-const originalAgentRepos = process.env.AGENT_REPOS;
-
 describe("onGitHubEvent", () => {
   let server: SetupServer | undefined;
 
@@ -200,12 +198,10 @@ describe("onGitHubEvent", () => {
 
   beforeEach(() => {
     server?.resetHandlers();
-    process.env.AGENT_REPOS = "PioneerSquareLabs/t3-starter-template";
   });
 
   afterEach(() => {
     vi.clearAllMocks();
-    process.env.AGENT_REPOS = originalAgentRepos;
   });
 
   afterAll(() => {
@@ -277,8 +273,6 @@ describe("onGitHubEvent", () => {
   });
 
   test("issue opened - edit files", async () => {
-    process.env.AGENT_REPOS = "";
-
     await onGitHubEvent({
       id: "2",
       name: "issues",
@@ -307,8 +301,6 @@ describe("onGitHubEvent", () => {
   });
 
   test("base branch command - issue opened - edit files", async () => {
-    process.env.AGENT_REPOS = "";
-
     await onGitHubEvent({
       id: "2",
       name: "issues",
@@ -401,8 +393,6 @@ describe("onGitHubEvent", () => {
 
   // TODO: Write tests for agent fix error
   test("PR comment created - fix build/test error command", async () => {
-    process.env.AGENT_REPOS = "";
-
     await onGitHubEvent({
       id: "5",
       name: "issue_comment",

--- a/src/server/messaging/queue.ts
+++ b/src/server/messaging/queue.ts
@@ -277,11 +277,7 @@ async function onReposAdded(
       const repoSettings = await getRepoSettings(path, repo.full_name);
 
       try {
-        if (
-          process.env.AGENT_REPOS?.split(",")
-            .map((repo) => repo.trim())
-            .includes(repo.full_name)
-        ) {
+        if (project.agentEnabled) {
           // for the agent repos, we will run the research codebase agent
           const allFiles = traverseCodebase(path);
           console.log(
@@ -651,9 +647,7 @@ export async function onGitHubEvent(event: WebhookQueuedEvent) {
             },
           });
         } else {
-          // const editFunction = (process.env.AGENT_REPOS ?? "")
-          //   .split(",")
-          //   .includes(repository.full_name)
+          // const editFunction = project.agentEnabled
           //   ? agentEditFiles
           //   : editFiles;
           // For now use the non-agent version
@@ -770,11 +764,7 @@ export async function onGitHubEvent(event: WebhookQueuedEvent) {
               );
               break;
             }
-            // const fixFunction = (process.env.AGENT_REPOS ?? "")
-            //   .split(",")
-            //   .includes(repository.full_name)
-            //   ? agentFixError
-            //   : fixError;
+            // const fixFunction = project.agentEnabled ? agentFixError : fixError;
             // For now use the non-agent version
             await fixError({
               ...baseEventData,

--- a/src/server/utils/todos.ts
+++ b/src/server/utils/todos.ts
@@ -13,8 +13,6 @@ import { getRepoSettings, type RepoSettings } from "./settings";
 import { getOrCreateCodebaseContext } from "./codebaseContext";
 import { traverseCodebase } from "../analyze/traverse";
 
-const agentRepos = (process.env.AGENT_REPOS ?? "").split(",") ?? [];
-
 interface GetOrCreateTodoParams {
   repo: string;
   projectId: number;
@@ -22,6 +20,7 @@ interface GetOrCreateTodoParams {
   accessToken?: string;
   rootDir?: string;
   sourceMap?: string;
+  agentEnabled?: boolean;
   repoSettings?: RepoSettings;
 }
 
@@ -32,6 +31,7 @@ export const getOrCreateTodo = async ({
   accessToken,
   rootDir,
   sourceMap,
+  agentEnabled,
   repoSettings,
 }: GetOrCreateTodoParams) => {
   const [repoOwner, repoName] = repo?.split("/") ?? [];
@@ -95,7 +95,7 @@ export const getOrCreateTodo = async ({
 
     // Only research issues and create plans for agent repos for now
     // TODO: only research issues for premium accounts
-    if (agentRepos.includes(repo?.trim())) {
+    if (agentEnabled) {
       const allFiles = traverseCodebase(rootPath);
       const codebaseContext = await getOrCreateCodebaseContext(
         projectId,
@@ -117,11 +117,7 @@ export const getOrCreateTodo = async ({
       });
       await getOrCreateResearchForProject(projectId, codebaseContext);
     } else {
-      console.log(
-        `Skipping research for repo ${repo} issue #${issue.number}. Agent repos are ${agentRepos.join(
-          ", ",
-        )}`,
-      );
+      console.log(`Skipping research for repo ${repo} issue #${issue.number}.`);
     }
 
     console.log(`Created new todo for issue #${issue.number}`);

--- a/src/server/webhooks/github.ts
+++ b/src/server/webhooks/github.ts
@@ -70,6 +70,7 @@ ghApp.webhooks.on("issues.opened", async (event) => {
         const todo = await getOrCreateTodo({
           repo: repository.full_name,
           projectId: project.id,
+          agentEnabled: project.agentEnabled,
           issueNumber: payload.issue.number,
           accessToken: installationAuthentication?.token,
         });


### PR DESCRIPTION
* Retire `DASHBOARD_USERS` and `AGENT_REPOS` env variables
* Instead, use `dashboardEnabled` on the `User` and `agentEnabled` on the `Project`
* NOTE: I've manually migrated the data into the DB on production - with a few exceptions where the users or projects did not exist